### PR TITLE
docs: fixed missing references

### DIFF
--- a/aiogremlin/driver/client.py
+++ b/aiogremlin/driver/client.py
@@ -8,11 +8,11 @@ from gremlin_python.process import traversal
 
 class Client:
     """
-    Client that utilizes a :py:class:`Cluster<aiogremlin.cluster.Cluster>`
+    Client that utilizes a :py:class:`Cluster<aiogremlin.driver.cluster.Cluster>`
     to access a cluster of Gremlin Server hosts. Issues requests to hosts using
     a round robin strategy.
 
-    :param aiogremlin.cluster.Cluster cluster: Cluster used by
+    :param aiogremlin.driver.cluster.Cluster cluster: Cluster used by
         client
     :param asyncio.BaseEventLoop loop:
     :param dict aliases: Optional mapping for aliases. Default is `None`
@@ -59,7 +59,7 @@ class Client:
         **coroutine** Submit a script and bindings to the Gremlin Server.
 
         :param message: Can be an instance of
-            `Message<gremlin_python.request.RequestMessage>` or
+            `RequestMessage<gremlin_python.driver.request.RequestMessage>` or
             `Bytecode<gremlin_python.process.traversal.Bytecode>`
             or a `str` representing a raw Gremlin script
         :param dict bindings: Optional bindings used with raw Grelmin

--- a/aiogremlin/driver/connection.py
+++ b/aiogremlin/driver/connection.py
@@ -20,7 +20,7 @@ class Connection:
     """
     Main classd for interacting with the Gremlin Server. Encapsulates a
     websocket connection. Not instantiated directly. Instead use
-    :py:meth:`Connection.open<aiogremlin.connection.Connection.open>`.
+    :py:meth::`Connection.open<aiogremlin.driver.connection.Connection.open>`.
 
     :param str url: url for host Gremlin Server
     :param gremlin_python.driver.transport.AbstractBaseTransport transport:
@@ -71,7 +71,7 @@ class Connection:
         :param asyncio.BaseEventLoop loop:
         :param gremlin_python.driver.protocol.AbstractBaseProtocol protocol:
             Protocol implementation
-        :param func transport_factory: Factory function for transports
+        :param transport_factory: Factory function for transports
         :param ssl.SSLContext ssl_context:
         :param str username: Username for database auth
         :param str password: Password for database auth
@@ -82,7 +82,7 @@ class Connection:
         :param message_serializer: Message serializer implementation
         :param provider: Graph provider object implementation
 
-        :returns: :py:class:`Connection<aiogremlin.connection.Connection>`
+        :returns: :py:class:`Connection<aiogremlin.driver.connection.Connection>`
         """
         if not protocol:
             protocol = GremlinServerWSProtocol(message_serializer)

--- a/aiogremlin/driver/pool.py
+++ b/aiogremlin/driver/pool.py
@@ -8,11 +8,11 @@ from aiogremlin.driver import connection
 
 class PooledConnection:
     """
-    Wrapper for :py:class:`Connection<aiogremlin.connection.Connection>`
+    Wrapper for :py:class:`Connection<aiogremlin.driver.connection.Connection>`
     that helps manage tomfoolery associated with connection pooling.
 
-    :param aiogremlin.connection.Connection conn:
-    :param aiogremlin.pool.ConnectionPool pool:
+    :param aiogremlin.driver.connection.Connection conn:
+    :param aiogremlin.driver.pool.ConnectionPool pool:
     """
     def __init__(self, conn, pool):
         self._conn = conn
@@ -45,7 +45,7 @@ class PooledConnection:
         :param args: Keyword arguments for Gremlin Server. Depend on processor
             and op.
 
-        :returns: :py:class:`Response` object
+        :returns: :py:class:`aiohttp.ClientResponse` object
         """
         return await self._conn.write(message)
 

--- a/aiogremlin/driver/server.py
+++ b/aiogremlin/driver/server.py
@@ -45,7 +45,7 @@ class GremlinServer:
         """
         Readonly property.
 
-        :returns: :py:class:`ConnectionPool<goblin.driver.pool.ConnectionPool>`
+        :returns: :py:class:`ConnectionPool<aiogremlin.driver.pool.ConnectionPool>`
         """
         if self._pool:
             return self._pool

--- a/aiogremlin/process/graph_traversal.py
+++ b/aiogremlin/process/graph_traversal.py
@@ -22,18 +22,21 @@ class AsyncGraphTraversal(graph_traversal.GraphTraversal):
         return object
 
     async def toList(self):
+        """Reture results as ``list``."""
         results = []
         async for result in self:
             results.append(result)
         return results
 
     async def toSet(self):
+        """Return results as ``set``."""
         results = set()
         async for result in self:
             results.add(result)
         return results
 
     async def iterate(self):
+        """Iterate over results."""
         while True:
             try:
                 await self.nextTraverser()
@@ -41,6 +44,7 @@ class AsyncGraphTraversal(graph_traversal.GraphTraversal):
                 return self
 
     async def nextTraverser(self):
+        """Return next traverser."""
         if self.traversers is None:
             await self.traversal_strategies.apply_strategies(self)
         if self.last_traverser is None:
@@ -51,6 +55,7 @@ class AsyncGraphTraversal(graph_traversal.GraphTraversal):
             return temp
 
     async def next(self, amount=None):
+        """Return iterator with optionaly defined amount of items."""
         if not amount:
             try:
                 return await self.__anext__()

--- a/docs/aiogremlin.driver.rst
+++ b/docs/aiogremlin.driver.rst
@@ -30,6 +30,8 @@ aiogremlin\.driver\.cluster module
 aiogremlin\.driver\.connection module
 -------------------------------------
 
+.. autoclass:: gremlin_python.driver.protocol.AbstractBaseProtocol
+
 .. automodule:: aiogremlin.driver.connection
     :members:
     :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ html_theme_path = [alabaster.get_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -5,3 +5,26 @@ aiogremlin API
    :maxdepth: 4
 
    aiogremlin
+
+External References
+-------------------
+
+.. autoclass:: gremlin_python.driver.transport.AbstractBaseTransport
+
+.. autoclass:: gremlin_python.driver.remote_connection.RemoteStrategy
+
+.. autoclass:: gremlin_python.driver.request.RequestMessage
+
+.. autoclass:: gremlin_python.process.graph_traversal.GraphTraversal
+
+.. autoclass:: gremlin_python.process.graph_traversal.GraphTraversalSource
+
+.. autoclass:: gremlin_python.process.traversal.Bytecode
+
+.. autoclass:: gremlin_python.process.traversal.Traversal
+
+.. autoclass:: gremlin_python.process.traversal.TraversalSideEffects
+
+.. autoclass:: gremlin_python.process.traversal.TraversalStrategies
+
+.. autoclass:: gremlin_python.structure.graph.Graph

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,8 +37,10 @@ by PEP 492::
     >>> async for vertex in g.V():
     ...     print(vertex)
 
-Furthermore, it implements several convience methods - :py:meth:`toList`,
-:py:meth:`toSet`, and :py:meth:`next`::
+Furthermore, it implements several convience methods -
+:py:meth:`toList<aiogremlin.process.graph_traversal.AsyncGraphTraversal.toList>`,
+:py:meth:`toSet<aiogremlin.process.graph_traversal.AsyncGraphTraversal.toSet>`,
+and :py:meth:`next<aiogremlin.process.graph_traversal.AsyncGraphTraversal.next>`::
 
     >>> vertex_list = await g.V().toList()
     >>> vertex_set = await g.V().toSet()
@@ -138,7 +140,7 @@ async interator protocol::
     ...     print(v)
 
 It also provides a convenience method
-:py:meth:`all<aiogremlin.driver.client.Client.all>`
+:py:meth:`all<aiogremlin.driver.resultset.ResultSet.all>`
 that aggregates and returns the result of the script in a :py:class:`list`::
 
     >>> results = await result_set.all()


### PR DESCRIPTION
* Allows building documentation in strict mode with:
  `sphinx-build -qnNW docs docs/_build/html`  (closes #9)